### PR TITLE
(chore): convert all underscores to hyphens in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export PATH=$PATH:$HOME/go/bin
 1. Terminate the running server with `ctrl C` and and navigate to the `pmguides` source directory `cd pmguides/src`
    - In this directory, you will see all existing guides and their markdown files.
 2. Generate a new guide from the guide template `npm run template <GUIDE_NAME>`
-   - Don't use spaces in the name of your guide, instead use underscores.
+   - Don't use spaces in the name of your guide, instead use **hyphens** to seperate words.
 3. Navigate to the newly generated guide (`cd pmguides/src/<GUIDE_NAME>`) and edit your guide in a tool like vscode.
 4. Run the website again `npm run serve`
 5. As you edit and save changes, your changes will automatically load in the browser.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export PATH=$PATH:$HOME/go/bin
 1. Terminate the running server with `ctrl C` and and navigate to the `pmguides` source directory `cd pmguides/src`
    - In this directory, you will see all existing guides and their markdown files.
 2. Generate a new guide from the guide template `npm run template <GUIDE_NAME>`
-   - Don't use spaces in the name of your guide, instead use **hyphens** to seperate words.
+   - Don't use spaces in the name of your guide, instead use **hyphens** to separate words.
 3. Navigate to the newly generated guide (`cd pmguides/src/<GUIDE_NAME>`) and edit your guide in a tool like vscode.
 4. Run the website again `npm run serve`
 5. As you edit and save changes, your changes will automatically load in the browser.

--- a/site/app/views/fr/index.html
+++ b/site/app/views/fr/index.html
@@ -215,7 +215,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
              All other views are explicitly opt-in via metadata. #}
           {% if codelab.status.indexOf('hidden') === -1 || view.id !== 'default' %}
             {% set cat = levelledCategory(codelab, view.catLevel) %}
-            <a href="{{codelabUrl(view, codelab).split('_').join('-')}}" on-tap="navigate"
+            <a href="{{codelabUrl(view, codelab)}}" on-tap="navigate"
                class="codelab-card category-{{categoryClass(codelab, cat.level)}}"
                data-category="{{codelab.category}}"
                data-title="{{codelab.title}}"

--- a/site/app/views/fr/index.html
+++ b/site/app/views/fr/index.html
@@ -215,7 +215,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
              All other views are explicitly opt-in via metadata. #}
           {% if codelab.status.indexOf('hidden') === -1 || view.id !== 'default' %}
             {% set cat = levelledCategory(codelab, view.catLevel) %}
-            <a href="{{codelabUrl(view, codelab)}}" on-tap="navigate"
+            <a href="{{codelabUrl(view, codelab).split('_').join('-')}}" on-tap="navigate"
                class="codelab-card category-{{categoryClass(codelab, cat.level)}}"
                data-category="{{codelab.category}}"
                data-title="{{codelab.title}}"

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -638,7 +638,14 @@ const generateView = () => {
 
     // Get the list of codelabs and categories for this view
     const filtered = filterCodelabs(view, all.codelabs);
-    const codelabs = filtered.codelabs;
+    let codelabs = filtered.codelabs;
+    // Convert all codelab IDs from underscore(_) to dash(-)
+    codelabs = codelabs.map(codelab => {
+      codelab.id = codelab.id.split('_').join('-')
+      codelab.url = codelab.url.split('_').join('-')
+      
+      return codelab;
+    });
     const categories = filtered.categories;
 
     let locals = {
@@ -723,6 +730,7 @@ const viewFuncs = {
   codelabUrl: (params) => {
     return (view, codelab) => {
       let url = codelab.url;
+
       if (params !== undefined) {
         url = `${url}?${params}`;
       }

--- a/site/pmguides/src/15_days_of_postman/15_days_of_postman.md
+++ b/site/pmguides/src/15_days_of_postman/15_days_of_postman.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: 15_days_of_postman
+id: 15-days-of-postman
 summary: Improve your skills by tackling a new Postman challenge for 15 days in a row
 categories: Tester, Intermediate
 environments: web

--- a/site/pmguides/src/15_days_of_postman_fr/15_days_of_postman_fr.md
+++ b/site/pmguides/src/15_days_of_postman_fr/15_days_of_postman_fr.md
@@ -1,5 +1,5 @@
 author: Arlemi
-id: 15_days_of_postman_fr
+id: 15-days-of-postman-fr
 summary: This is a sample Postman Guide
 categories: Tester, Intermediate
 environments: web

--- a/site/pmguides/src/30_days_of_postman/30_days_of_postman.md
+++ b/site/pmguides/src/30_days_of_postman/30_days_of_postman.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: 30_days_of_postman
+id: 30-days-of-postman
 summary: Improve your skills by tackling a new Postman challenge for 30 days in a row
 categories: Getting-Started, Developer
 environments: web

--- a/site/pmguides/src/_template/markdown.template
+++ b/site/pmguides/src/_template/markdown.template
@@ -1,5 +1,5 @@
 author: AUTHOR_NAME
-id: PMGUIDE_NAME
+id: PMGUIDE-NAME
 summary: This is a sample Postman Guide
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/a_postman_tutorial_for_snowflake_sql_api/a_postman_tutorial_for_snowflake_sql_api.md
+++ b/site/pmguides/src/a_postman_tutorial_for_snowflake_sql_api/a_postman_tutorial_for_snowflake_sql_api.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: a_postman_tutorial_for_snowflake_sql_api
+id: a-postman-tutorial-for-snowflake-sql-api
 summary: Explore the Snowflake SQL API with Postman
 categories: Getting-Started, Data
 environments: web

--- a/site/pmguides/src/connect_postman_to_salesforce/connect_postman_to_salesforce.md
+++ b/site/pmguides/src/connect_postman_to_salesforce/connect_postman_to_salesforce.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: connect_postman_to_salesforce
+id: connect-postman-to-salesforce
 summary: Set up Postman with the Salesforce API collection to access data in your Salesforce org.
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/continuous_quality/continuous_quality.md
+++ b/site/pmguides/src/continuous_quality/continuous_quality.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: continuous_quality
+id: continuous-quality
 summary: Advanced testing workflows in Postman
 categories: Tester, Intermediate
 environments: web

--- a/site/pmguides/src/galaxy_testing_and_automation/galaxy_testing_and_automation.md
+++ b/site/pmguides/src/galaxy_testing_and_automation/galaxy_testing_and_automation.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: galaxy_testing_and_automation
+id: galaxy-testing-and-automation
 summary: This is a tutorial for testing and automation in Postman
 categories: Getting-Started, Tester
 environments: web

--- a/site/pmguides/src/http_cats/http_cats.md
+++ b/site/pmguides/src/http_cats/http_cats.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: http_cats
+id: http-cats
 summary: Learn HTTP Status Codes with HTTP Cats
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/introduction_to_apis/introduction_to_postman.md
+++ b/site/pmguides/src/introduction_to_apis/introduction_to_postman.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: introduction_to_postman
+id: introduction-to-postman
 summary: This is a beginner's introduction to HTTP APIs in Postman
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/lost_in_space/lost_in_space.md
+++ b/site/pmguides/src/lost_in_space/lost_in_space.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: lost_in_space
+id: lost-in-space
 summary: This is a Postman puzzle game
 categories: Game
 environments: web

--- a/site/pmguides/src/lost_in_space_fr/lost_in_space_fr.md
+++ b/site/pmguides/src/lost_in_space_fr/lost_in_space_fr.md
@@ -1,5 +1,5 @@
 author: Arlemi
-id: lost_in_space_fr
+id: lost-in-space-fr
 summary: Puzzle se jouant sur Postman
 categories: Game
 environments: web

--- a/site/pmguides/src/microsoft_graph/microsoft_graph.md
+++ b/site/pmguides/src/microsoft_graph/microsoft_graph.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: microsoft_graph
+id: microsoft-graph
 summary: Get Started with the Microsoft Graph API in Postman
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/mongodb_atlas_data/mongodb_atlas_data.md
+++ b/site/pmguides/src/mongodb_atlas_data/mongodb_atlas_data.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: mongodb_atlas_data
+id: mongodb-atlas-data
 summary: Get Started with the MongoDB Atlas Data API
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/php_laravel_API/laravel.md
+++ b/site/pmguides/src/php_laravel_API/laravel.md
@@ -1,5 +1,5 @@
 author: Greg Bulmash
-id: php_laravel_API
+id: php-laravel-API
 summary: Create A REST API with PHP And Laravel 
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/php_symfony_API/symfony.md
+++ b/site/pmguides/src/php_symfony_API/symfony.md
@@ -1,5 +1,5 @@
 author: Greg Bulmash
-id: php_symfony_API
+id: php-symfony-API
 summary: Create A REST API with PHP And Symfony 
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/postman_flows_tutorials/postman_flows_tutorials.md
+++ b/site/pmguides/src/postman_flows_tutorials/postman_flows_tutorials.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: postman_flows_tutorials
+id: postman-flows-tutorials
 summary: Get started with different types of Postman Flows
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/postman_supernovas/postman_supernovas.md
+++ b/site/pmguides/src/postman_supernovas/postman_supernovas.md
@@ -1,5 +1,5 @@
 author: kcorb95
-id: postman_supernovas
+id: postman-supernovas
 summary: Become a Postman ambassador and empower the API developer & tester community by building community around the world today.
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/securing_api_keys/securing_api_keys.md
+++ b/site/pmguides/src/securing_api_keys/securing_api_keys.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: securing_api_keys
+id: securing-api-keys
 summary: Three ways to securely work with API keys
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/snapshot_testing/snapshot_testing.md
+++ b/site/pmguides/src/snapshot_testing/snapshot_testing.md
@@ -1,5 +1,5 @@
 author: Prashant Agrawal
-id: snapshot_testing
+id: snapshot-testing
 summary: Three different snapshot testing strategies
 categories: Tester, Intermediate
 environments: web

--- a/site/pmguides/src/websockets_node/websockets_node.md
+++ b/site/pmguides/src/websockets_node/websockets_node.md
@@ -1,5 +1,5 @@
 author: Joyce
-id: websockets_node
+id: websockets-node
 summary: Set up a WebSockets server in Node.js
 categories: Getting-Started
 environments: web

--- a/site/pmguides/src/websockets_python/websockets_python.md
+++ b/site/pmguides/src/websockets_python/websockets_python.md
@@ -1,5 +1,5 @@
 author: Greg Bulmash
-id: websockets_python
+id: websockets-python
 summary: Set up a WebSockets server in Python
 categories: Getting-Started
 environments: web


### PR DESCRIPTION
This PR fixes #34.

It modifies all the markdown files to use underscores and includes a script that dynamically does that incase it was skipped.